### PR TITLE
Make autocomplete with external keyboard behave better

### DIFF
--- a/OpenTerm/View/TerminalView.swift
+++ b/OpenTerm/View/TerminalView.swift
@@ -361,24 +361,13 @@ extension TerminalView {
 	}
 
 	@objc func completeCommand() {
-		guard let firstCompletion = autoCompleteManager.completions.first?.name,
-			currentCommand != firstCompletion else {
-				return
-		}
 
-		let completed: String
-		if let lastCommand = currentCommand.components(separatedBy: " ").last {
-			if lastCommand.isEmpty {
-				completed = currentCommand + firstCompletion
-			} else {
-				completed = currentCommand.replacingOccurrences(of: lastCommand, with: firstCompletion, options: .backwards)
-			}
-		} else {
-			completed = firstCompletion
-		}
+		guard
+			let firstCompletion = autoCompleteManager.completions.first,
+			currentCommand != firstCompletion.name
+			else { return }
 
-		currentCommand = completed
-		autoCompleteManager.reloadData()
+		insertCompletion(firstCompletion)
 	}
 }
 


### PR DESCRIPTION
When the user presses "tab" on an external keyboard, OpenTerm calls `completeCommand`, which completes the command. This command is different from the standard auto-complete method, and it has several issues: it can't autocomplete on a directory inside a directory, and it replaces all occurences of the search string with the replacement string, causing problems ("diff di[tab]" produces "diff.cff diff.c", which was not what I expected). 

Rather than rewrite everything, I suggest we call autoComplete `insertCompletion`, which already updates currentCommand and calls `autoCompleteManager.reloadData()`. 